### PR TITLE
Add browle.com — verified made-in directory for European brands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 >Also for Awesome European Tech: https://github.com/uscneps/Awesome-European-Tech
 
+>To check where a brand actually manufactures: https://browle.com — verified made-in directory for European brands, evidence link on every entry (EN/DE/FR)
+
 You can check this same one but hosted in EU github alternative: https://codeberg.org/Made-in-EU/Made-in-EU
 
 ## Preamble


### PR DESCRIPTION
## Summary
- Adds browle.com to the header website pointers, next to european-alternatives.eu and Awesome European Tech.
- browle answers one narrow question this list's users keep running into: **where is this product actually manufactured?** 631 European brands, each entry carries a public evidence link (the brand's own factory/made-in statement or equivalent) plus a last-verified date, in EN/DE/FR. Brands whose production claims don't hold up are documented too, with sources.
- Scope matches this repo's spirit: physical products, honest per-line scoping (e.g. Salomon is marked "select lines in France" rather than blanket made-in-France).

Disclosure: I run browle. It's free, no ads, no tracking cookies; affiliate links, where present, are marked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)